### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/aog-article/_schema.yml
+++ b/_extensions/aog-article/_schema.yml
@@ -1,0 +1,24 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  aog-article-pdf:
+    fontsize:
+      type: string
+      description: Base font size such as 10pt, 11pt, or 12pt.
+    geometry:
+      type: string
+      description: Geometry options for PDF page layout.
+    fig-width:
+      type: number
+      description: Default figure width in inches.
+    fig-pos:
+      type: string
+      description: Preferred LaTeX float placement token.
+    colorlinks:
+      type: boolean
+      description: Enable coloured links in PDF output.
+    urlcolor:
+      type: string
+      description: URL link colour in PDF output.
+      completion:
+        type: color

--- a/_extensions/aog-article/_snippets.json
+++ b/_extensions/aog-article/_snippets.json
@@ -1,0 +1,22 @@
+{
+  "AOG format setup": {
+    "prefix": "format",
+    "body": [
+      "format:",
+      "  aog-article-pdf: default"
+    ],
+    "description": "Enable AOG article PDF format."
+  },
+  "AOG PDF options": {
+    "prefix": "options",
+    "body": [
+      "format:",
+      "  aog-article-pdf:",
+      "    fontsize: ${1:12pt}",
+      "    geometry: ${2:margin=1in}",
+      "    fig-width: ${3:6.5}",
+      "    fig-pos: \"${4:!t}\""
+    ],
+    "description": "Insert common AOG format option overrides."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/aog-article/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/aog-article/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
